### PR TITLE
♿️ BP-312 accessibility fixes (input label, checkbox event handler)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipetro/template-react-component-library",
-  "version": "1.1.71",
+  "version": "1.1.72",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipetro/template-react-component-library",
-      "version": "1.1.71",
+      "version": "1.1.72",
       "license": "ISC",
       "dependencies": {
         "@rollup/plugin-typescript": "^8.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipetro/template-react-component-library",
-  "version": "1.1.71",
+  "version": "1.1.72",
   "description": "A simple template for a custom React component library",
   "scripts": {
     "rollup": "rollup -c",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,6 +14,12 @@ export interface ButtonProps {
   children: React.ReactNode;
 }
 
+const variantColorMap = {
+  positive: colors.POSITIVE,
+  negative: colors.NEGATIVE,
+  neutral: colors.NEUTRAL,
+}
+
 const Button: React.FC<ButtonProps> = ({
   type = 'primary',
   variant = 'positive',
@@ -24,8 +30,7 @@ const Button: React.FC<ButtonProps> = ({
   icon,
   ...rest
 }) => {
-  const variantColor =
-    variant === 'positive' ? colors.POSITIVE : variant === 'negative' ? colors.NEGATIVE : colors.NEUTRAL;
+  const variantColor = variantColorMap[variant] ?? colors.NEUTRAL;
 
   return (
     <button

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ type CheckboxProps = {
   defaultValue?: boolean;
   value?: boolean;
   disabled?: boolean;
-  onClick?: React.MouseEventHandler<HTMLElement>;
+  onClick?: React.ChangeEventHandler<HTMLInputElement>;
   required?: boolean;
 };
 const Checkbox: React.FC<CheckboxProps> = ({
@@ -37,7 +37,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
         <input
           type="checkbox"
           name={name}
-          onClick={onClick}
+          onChange={onClick}
           required={required}
           defaultChecked={defaultValue}
           checked={value}

--- a/src/components/SelectItem/SelectItem.tsx
+++ b/src/components/SelectItem/SelectItem.tsx
@@ -41,7 +41,7 @@ const SelectItem: React.FC<SelectItemProps> = ({
   return (
     <div className={className}>
       {label && (
-        <label className={`${labelClass} ${styles['label']}`}>
+        <label className={`${labelClass} ${styles['label']}`} htmlFor={name}>
           <span dangerouslySetInnerHTML={{ __html: label }} />
           {required && <span className={styles['required']}>*</span>}
         </label>
@@ -57,6 +57,7 @@ const SelectItem: React.FC<SelectItemProps> = ({
         isSearchable={searchable}
         isClearable={clearable}
         value={value}
+        inputId={name}
       />
       {error && <div className={styles['errorDescription']}>{error}</div>}
     </div>

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -19,7 +19,7 @@ const TextArea: React.FC<TextAreaProps> = ({
   label,
   name,
   placeholder,
-  labelClass,
+  labelClass='',
   description = null,
   defaultValue,
   disabled = false,
@@ -31,13 +31,14 @@ const TextArea: React.FC<TextAreaProps> = ({
   return (
     <div>
       {label && (
-        <label className={`${labelClass && labelClass} ${styles['label']}`}>
+        <label className={`${labelClass} ${styles['label']}`} htmlFor={name}>
           <span dangerouslySetInnerHTML={{ __html: label }} />
           {required && <span className={styles['required']}>*</span>}
         </label>
       )}
       <textarea
         name={name}
+        id={name}
         className={`${styles['textarea']} ${disabled && styles['disabled']}`}
         onChange={onChange}
         onBlur={onBlur}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -57,7 +57,7 @@ const TextField: React.FC<TextFieldProps> = ({
   return (
     <div className={styles['textFieldWrapper']}>
       {label && (
-        <label className={`${labelClass && labelClass} ${styles['label']}`}>
+        <label className={`${labelClass ? labelClass : ''} ${styles['label']}`} htmlFor={name}>
           <span dangerouslySetInnerHTML={{ __html: label }} />
           {required && <span className={styles['required']}>*</span>}
         </label>


### PR DESCRIPTION
This PR aims to:
- connect labels to input field (improves accessibility)
- replaced `onClick` to `onChange` in checkboxes; onChange is preferred to onClick for checkboxes
<img width="977" alt="image" src="https://user-images.githubusercontent.com/40042573/233219736-5334b471-f14a-4850-ab5c-902a8f836f9b.png">
